### PR TITLE
Fix checkpoint revert loop

### DIFF
--- a/Assets/Scripts/Level/LevelCheckPointsManager.cs
+++ b/Assets/Scripts/Level/LevelCheckPointsManager.cs
@@ -25,6 +25,12 @@ namespace Level
             _currentCheckPointIndex = GetCheckPointIndex(checkPoint);
         }
 
+        public void SetCurrentToLastCheckPoint()
+        {
+            currentCheckPointPosition = checkPoints[_lastCheckPointIndex].transform.position;
+            _currentCheckPointIndex = _lastCheckPointIndex;
+        }
+
         public GameObject GetLastCheckPoint()
         {
             return checkPoints[_lastCheckPointIndex];

--- a/Assets/Scripts/Level/LevelManager.cs
+++ b/Assets/Scripts/Level/LevelManager.cs
@@ -28,7 +28,7 @@ namespace Level
 
         public void GoToLastCheckpoints()
         {
-            levelCheckPointsManager.SetCurrentCheckPoint(levelCheckPointsManager.GetLastCheckPoint());
+            levelCheckPointsManager.SetCurrentToLastCheckPoint();
             player.TP(levelCheckPointsManager.currentCheckPointPosition);
         }
 


### PR DESCRIPTION
## Summary
- ensure the player can return to the last checkpoint multiple times
- add `SetCurrentToLastCheckPoint` to `LevelCheckPointsManager`
- use the new method in `LevelManager`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a091db4a8832f8cc03f454cbece4c